### PR TITLE
Refine filter state handling on HomeScreen

### DIFF
--- a/app/src/main/java/com/easyestate/android/ui/HomeScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/HomeScreen.kt
@@ -35,10 +35,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -58,7 +56,7 @@ fun HomeScreen(
     modifier: Modifier = Modifier
 ) {
     val filters = listOf("All", "Occupied", "Vacant", "Commercial")
-    var selectedFilter by remember { mutableStateOf(filters.first()) }
+    val selectedFilter = remember { mutableStateOf(filters.first()) }
 
     val properties = sampleProperties
     val rentStatuses = sampleRentStatus
@@ -73,8 +71,8 @@ fun HomeScreen(
             item {
                 FilterSection(
                     filters = filters,
-                    selected = selectedFilter,
-                    onSelect = { selectedFilter = it }
+                    selected = selectedFilter.value,
+                    onSelect = { selectedFilter.value = it }
                 )
             }
             item {


### PR DESCRIPTION
## Summary
- hold the selected filter on the home screen as a remembered mutable state object
- update filter selection reads and writes to go through the state's value and drop unused delegate imports

## Testing
- ./gradlew :app:assemble *(fails: no main manifest attribute in gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc9a638908323a12346d29a6c1edb