### PR TITLE
Launch app directly to home screen

### DIFF
--- a/app/src/main/java/com/easyestate/android/MainActivity.kt
+++ b/app/src/main/java/com/easyestate/android/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.navigation.compose.rememberNavController
 import com.easyestate.android.ui.AuthUiEvent
 import com.easyestate.android.ui.AuthViewModel
 import com.easyestate.android.ui.HomeScreen
-import com.easyestate.android.ui.LoginScreen
-import com.easyestate.android.ui.SignUpScreen
 import com.easyestate.android.ui.theme.EasyEstateTheme
 import kotlinx.coroutines.launch
 
@@ -77,25 +75,9 @@ fun EasyEstateApp(
     ) { padding ->
         NavHost(
             navController = navController,
-            startDestination = AppDestination.Login.route,
+            startDestination = AppDestination.Home.route,
             modifier = Modifier.padding(padding)
         ) {
-            composable(AppDestination.Login.route) {
-                LoginScreen(
-                    onSignIn = { email, password -> authViewModel.signIn(email, password) },
-                    onSignUp = { navController.navigate(AppDestination.SignUp.route) },
-                    isLoading = uiState.isLoading
-                )
-            }
-            composable(AppDestination.SignUp.route) {
-                SignUpScreen(
-                    onSignUp = { name, email, password ->
-                        authViewModel.signUp(name, email, password)
-                    },
-                    onBackToLogin = { navController.popBackStack() },
-                    isLoading = uiState.isLoading
-                )
-            }
             composable(AppDestination.Home.route) {
                 HomeScreen(
                     adminName = uiState.currentAdminName ?: "Easy Estate Admin",
@@ -112,8 +94,6 @@ fun EasyEstateApp(
 }
 
 private enum class AppDestination(val route: String) {
-    Login("login"),
-    SignUp("signup"),
     Home("home")
 }
 

--- a/app/src/main/java/com/easyestate/android/ui/AuthViewModel.kt
+++ b/app/src/main/java/com/easyestate/android/ui/AuthViewModel.kt
@@ -95,7 +95,7 @@ class AuthViewModel : ViewModel() {
 data class AuthUiState(
     val isLoading: Boolean = false,
     val event: AuthUiEvent? = null,
-    val currentAdminName: String? = null,
+    val currentAdminName: String? = "Easy Estate Admin",
     val lastCreatedAccount: AdminAccount? = null
 )
 


### PR DESCRIPTION
## Summary
- start the navigation graph on the home destination so the app opens on the home screen
- remove the login and sign-up composables from the nav graph while authentication is disabled
- default the auth UI state's admin name to "Easy Estate Admin" so the home screen greeting remains populated

## Testing
- `./gradlew :app:assembleDebug` *(fails: no main manifest attribute in gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68dcdbaf3d448323b01c3a589dc7c6a7