### PR TITLE
feat: apply stitch palette to theme

### DIFF
--- a/app/src/main/java/com/easyestate/android/ui/theme/Color.kt
+++ b/app/src/main/java/com/easyestate/android/ui/theme/Color.kt
@@ -2,13 +2,30 @@ package com.easyestate.android.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-// Light palette inspired by product mockups
-val TealPrimary = Color(0xFF00B5C5)
-val TealSecondary = Color(0xFF67D7E1)
-val TealAccent = Color(0xFF00A0AF)
-val NeutralBackground = Color(0xFFF5F7FA)
+val StitchPrimary = Color(0xFF1AB741)
+val StitchOnPrimary = Color.White
+val StitchPrimaryContainer = Color(0xFFD1FFD9)
+val StitchOnPrimaryContainer = Color(0xFF00210B)
 
-// Dark palette complements for night mode usage
-val TealPrimaryDark = Color(0xFF00A7B7)
-val TealSecondaryDark = Color(0xFF4DBFC9)
-val NeutralSurfaceDark = Color(0xFF0F2024)
+val StitchSecondary = Color(0xFF0F7A2B)
+val StitchOnSecondary = Color.White
+val StitchSecondaryContainer = Color(0xFFBCECC7)
+val StitchOnSecondaryContainer = Color(0xFF00210B)
+
+val StitchTertiary = Color(0xFF3BA55D)
+val StitchOnTertiary = Color.White
+val StitchTertiaryContainer = Color(0xFFC8F2D5)
+val StitchOnTertiaryContainer = Color(0xFF00210B)
+
+val StitchLightBackground = Color(0xFFF6F8F6)
+val StitchLightOnBackground = Color(0xFF1E3323)
+val StitchLightSurface = Color(0xFFF6F8F6)
+val StitchLightOnSurface = Color(0xFF1E3323)
+
+val StitchDarkBackground = Color(0xFF112115)
+val StitchDarkOnBackground = Color(0xFFE0F1E3)
+val StitchDarkSurface = Color(0xFF1B3623)
+val StitchDarkOnSurface = Color(0xFFE0F1E3)
+
+val StitchOutline = Color(0xFF6DA47C)
+val StitchOutlineVariant = Color(0xFFB2D4BD)

--- a/app/src/main/java/com/easyestate/android/ui/theme/Theme.kt
+++ b/app/src/main/java/com/easyestate/android/ui/theme/Theme.kt
@@ -10,40 +10,57 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
-    primary = TealPrimaryDark,
-    onPrimary = NeutralSurfaceDark,
-    secondary = TealSecondaryDark,
-    onSecondary = NeutralSurfaceDark,
-    tertiary = TealAccent,
-    background = NeutralSurfaceDark,
-    surface = NeutralSurfaceDark,
-    onSurface = TealSecondary,
-    onBackground = TealSecondary
+    primary = StitchPrimary,
+    onPrimary = StitchOnPrimary,
+    primaryContainer = StitchPrimaryContainer,
+    onPrimaryContainer = StitchOnPrimaryContainer,
+    secondary = StitchSecondary,
+    onSecondary = StitchOnSecondary,
+    secondaryContainer = StitchSecondaryContainer,
+    onSecondaryContainer = StitchOnSecondaryContainer,
+    tertiary = StitchTertiary,
+    onTertiary = StitchOnTertiary,
+    tertiaryContainer = StitchTertiaryContainer,
+    onTertiaryContainer = StitchOnTertiaryContainer,
+    background = StitchDarkBackground,
+    onBackground = StitchDarkOnBackground,
+    surface = StitchDarkSurface,
+    onSurface = StitchDarkOnSurface,
+    outline = StitchOutline,
+    outlineVariant = StitchOutlineVariant
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = TealPrimary,
-    onPrimary = Color.White,
-    secondary = TealSecondary,
-    onSecondary = Color.White,
-    tertiary = TealAccent,
-    background = NeutralBackground,
-    surface = Color.White,
-    onSurface = Color(0xFF1B2C2F),
-    onBackground = Color(0xFF1B2C2F)
+    primary = StitchPrimary,
+    onPrimary = StitchOnPrimary,
+    primaryContainer = StitchPrimaryContainer,
+    onPrimaryContainer = StitchOnPrimaryContainer,
+    secondary = StitchSecondary,
+    onSecondary = StitchOnSecondary,
+    secondaryContainer = StitchSecondaryContainer,
+    onSecondaryContainer = StitchOnSecondaryContainer,
+    tertiary = StitchTertiary,
+    onTertiary = StitchOnTertiary,
+    tertiaryContainer = StitchTertiaryContainer,
+    onTertiaryContainer = StitchOnTertiaryContainer,
+    background = StitchLightBackground,
+    onBackground = StitchLightOnBackground,
+    surface = StitchLightSurface,
+    onSurface = StitchLightOnSurface,
+    outline = StitchOutline,
+    outlineVariant = StitchOutlineVariant
 )
 
 @Composable
 fun EasyEstateTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    dynamicColor: Boolean = true,
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {


### PR DESCRIPTION
## Summary
- replace the placeholder teal palette with the Stitch green and neutral tones, including container and outline variants
- wire Material3 light/dark schemes to the new palette and disable dynamic color by default so Stitch colors are always used

## Testing
- ./gradlew :app:assembleDebug *(fails: gradle wrapper jar missing manifest attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68dd498d067883238007f09714b2912b