### PR TITLE
Refresh landing screen branding and hero artwork

### DIFF
--- a/app/src/main/java/com/easyestate/android/ui/LandingScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/LandingScreen.kt
@@ -1,7 +1,7 @@
 package com.easyestate.android.ui
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,7 +21,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -48,15 +47,7 @@ fun LandingScreen(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth()
-                .background(
-                    Brush.verticalGradient(
-                        colors = listOf(
-                            colorScheme.primary,
-                            colorScheme.primary.copy(alpha = 0.85f),
-                            colorScheme.tertiary
-                        )
-                    )
-                ),
+                .background(colorScheme.background),
             contentAlignment = Alignment.BottomCenter
         ) {
             Image(

--- a/app/src/main/java/com/easyestate/android/ui/theme/Color.kt
+++ b/app/src/main/java/com/easyestate/android/ui/theme/Color.kt
@@ -4,28 +4,28 @@ import androidx.compose.ui.graphics.Color
 
 val StitchPrimary = Color(0xFF1AB741)
 val StitchOnPrimary = Color.White
-val StitchPrimaryContainer = Color(0xFFD1FFD9)
-val StitchOnPrimaryContainer = Color(0xFF00210B)
+val StitchPrimaryContainer = Color(0xFFD3F9DF)
+val StitchOnPrimaryContainer = Color(0xFF00210C)
 
-val StitchSecondary = Color(0xFF0F7A2B)
+val StitchSecondary = Color(0xFF118F33)
 val StitchOnSecondary = Color.White
-val StitchSecondaryContainer = Color(0xFFBCECC7)
-val StitchOnSecondaryContainer = Color(0xFF00210B)
+val StitchSecondaryContainer = Color(0xFFBFF0CB)
+val StitchOnSecondaryContainer = Color(0xFF00210C)
 
-val StitchTertiary = Color(0xFF3BA55D)
+val StitchTertiary = Color(0xFF45C36E)
 val StitchOnTertiary = Color.White
-val StitchTertiaryContainer = Color(0xFFC8F2D5)
-val StitchOnTertiaryContainer = Color(0xFF00210B)
+val StitchTertiaryContainer = Color(0xFFCFF7DA)
+val StitchOnTertiaryContainer = Color(0xFF00210C)
 
-val StitchLightBackground = Color(0xFFF6F8F6)
-val StitchLightOnBackground = Color(0xFF1E3323)
-val StitchLightSurface = Color(0xFFF6F8F6)
-val StitchLightOnSurface = Color(0xFF1E3323)
+val StitchLightBackground = Color(0xFFFFFFFF)
+val StitchLightOnBackground = Color(0xFF12341F)
+val StitchLightSurface = Color(0xFFFFFFFF)
+val StitchLightOnSurface = Color(0xFF12341F)
 
-val StitchDarkBackground = Color(0xFF112115)
-val StitchDarkOnBackground = Color(0xFFE0F1E3)
-val StitchDarkSurface = Color(0xFF1B3623)
-val StitchDarkOnSurface = Color(0xFFE0F1E3)
+val StitchDarkBackground = Color(0xFF102215)
+val StitchDarkOnBackground = Color(0xFFD7F0DF)
+val StitchDarkSurface = Color(0xFF18311F)
+val StitchDarkOnSurface = Color(0xFFD7F0DF)
 
-val StitchOutline = Color(0xFF6DA47C)
-val StitchOutlineVariant = Color(0xFFB2D4BD)
+val StitchOutline = Color(0xFF67C985)
+val StitchOutlineVariant = Color(0xFFB7E6C7)

--- a/app/src/main/res/drawable/landing_wave.xml
+++ b/app/src/main/res/drawable/landing_wave.xml
@@ -5,10 +5,10 @@
     android:viewportWidth="360"
     android:viewportHeight="200">
     <path
-        android:fillColor="#00B5C5"
-        android:pathData="M0,0h360v140c-62,-18 -118,54 -205,36C99,162 53,188 0,200z" />
+        android:fillColor="#1AB741"
+        android:pathData="M0,0h360v140c-29.17,-16.05 -63.21,-27.53 -101.04,-27.37 -46.66,0.2 -92.53,28.27 -138.25,46.18C81.82,176.24 40.74,181.65 0,192.5z" />
     <path
-        android:fillAlpha="0.65"
-        android:fillColor="#67D7E1"
-        android:pathData="M0,0h360v118c-74,40 -151,26 -222,42C87,174 44,168 0,152z" />
+        android:fillAlpha="0.85"
+        android:fillColor="#58D67D"
+        android:pathData="M0,0h360v118c-49.87,35.55 -105.97,45.43 -165.02,30.45 -43.5,-11.13 -90.3,-41.45 -136.96,-40.2C38.54,109.53 18.73,123.14 0,142.22z" />
 </vector>


### PR DESCRIPTION
## Summary
- align the Material 3 Stitch palette with the updated primary/secondary greens and neutral surfaces
- replace the landing wave drawable with the bright Stitch green SVG geometry
- simplify the landing hero background to a solid surface that showcases the new wave art

## Testing
- ⚠️ `./gradlew :app:compileDebugKotlin` *(fails: no main manifest attribute in gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68dd511f3aec8323bd4739a77caeca94