### PR TITLE
Update sign-up CTA styling

### DIFF
--- a/app/src/main/java/com/easyestate/android/ui/LandingScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/LandingScreen.kt
@@ -1,7 +1,6 @@
 package com.easyestate.android.ui
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -15,14 +14,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
@@ -112,17 +109,16 @@ fun LandingScreen(
                             color = colorScheme.onPrimary
                         )
                     }
-                    OutlinedButton(
+                    Button(
                         onClick = onSignUpClick,
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(54.dp),
                         shape = RoundedCornerShape(16.dp),
-                        colors = ButtonDefaults.outlinedButtonColors(
-                            containerColor = colorScheme.secondary.copy(alpha = 0.12f),
-                            contentColor = colorScheme.secondary
-                        ),
-                        border = BorderStroke(width = 0.dp, color = Color.Transparent)
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = colorScheme.primary.copy(alpha = 0.2f),
+                            contentColor = colorScheme.primary
+                        )
                     ) {
                         Text(
                             text = "Sign Up",


### PR DESCRIPTION
## Summary
- replace the sign-up CTA's outlined button with a filled button that uses a 20% primary tint and primary text
- retain the existing width, height, and corner radius to match the login button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd5126c6d8832396ae79d0b45a36b4