### PR TITLE
Update Stitch theme palette to green brand colors

### DIFF
--- a/app/src/main/java/com/easyestate/android/ui/theme/Color.kt
+++ b/app/src/main/java/com/easyestate/android/ui/theme/Color.kt
@@ -2,30 +2,33 @@ package com.easyestate.android.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val StitchPrimary = Color(0xFF1AB741)
+val StitchPrimary = Color(0xFF28A745)
+val StitchPrimaryLight = Color(0xFF5ED36A)
+val StitchPrimaryDark = Color(0xFF1E7F34)
 val StitchOnPrimary = Color.White
-val StitchPrimaryContainer = Color(0xFFD3F9DF)
-val StitchOnPrimaryContainer = Color(0xFF00210C)
 
-val StitchSecondary = Color(0xFF118F33)
+val StitchPrimaryContainer = Color(0xFFD6F5DF)
+val StitchOnPrimaryContainer = Color(0xFF042410)
+
+val StitchSecondary = Color(0xFF1F7343)
 val StitchOnSecondary = Color.White
-val StitchSecondaryContainer = Color(0xFFBFF0CB)
-val StitchOnSecondaryContainer = Color(0xFF00210C)
+val StitchSecondaryContainer = Color(0xFFC2E8CF)
+val StitchOnSecondaryContainer = Color(0xFF0A2916)
 
-val StitchTertiary = Color(0xFF45C36E)
+val StitchTertiary = Color(0xFF3FC16A)
 val StitchOnTertiary = Color.White
-val StitchTertiaryContainer = Color(0xFFCFF7DA)
-val StitchOnTertiaryContainer = Color(0xFF00210C)
+val StitchTertiaryContainer = Color(0xFFCBF5D7)
+val StitchOnTertiaryContainer = Color(0xFF04210F)
 
-val StitchLightBackground = Color(0xFFFFFFFF)
-val StitchLightOnBackground = Color(0xFF12341F)
+val StitchLightBackground = Color(0xFFF5F7F4)
+val StitchLightOnBackground = Color(0xFF102416)
 val StitchLightSurface = Color(0xFFFFFFFF)
-val StitchLightOnSurface = Color(0xFF12341F)
+val StitchLightOnSurface = Color(0xFF102416)
 
-val StitchDarkBackground = Color(0xFF102215)
-val StitchDarkOnBackground = Color(0xFFD7F0DF)
-val StitchDarkSurface = Color(0xFF18311F)
-val StitchDarkOnSurface = Color(0xFFD7F0DF)
+val StitchDarkBackground = Color(0xFF0F1E14)
+val StitchDarkOnBackground = Color(0xFFD9F0E1)
+val StitchDarkSurface = Color(0xFF15291B)
+val StitchDarkOnSurface = Color(0xFFD9F0E1)
 
-val StitchOutline = Color(0xFF67C985)
-val StitchOutlineVariant = Color(0xFFB7E6C7)
+val StitchOutline = Color(0xFF6AA478)
+val StitchOutlineVariant = Color(0xFFA9D0B2)

--- a/app/src/main/java/com/easyestate/android/ui/theme/Theme.kt
+++ b/app/src/main/java/com/easyestate/android/ui/theme/Theme.kt
@@ -16,9 +16,9 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
-    primary = StitchPrimary,
+    primary = StitchPrimaryLight,
     onPrimary = StitchOnPrimary,
-    primaryContainer = StitchPrimaryContainer,
+    primaryContainer = StitchPrimaryDark,
     onPrimaryContainer = StitchOnPrimaryContainer,
     secondary = StitchSecondary,
     onSecondary = StitchOnSecondary,


### PR DESCRIPTION
## Summary
- replace the legacy teal palette with Stitch green brand values and supporting neutrals
- wire the updated colors through the light and dark Material color schemes

## Testing
- not run (Compose preview requires Android Studio)

------
https://chatgpt.com/codex/tasks/task_e_68dd5a3c1f388323b63a095d6889d38b