### PR TITLE
Add missing layout weight import to LandingScreen

### DIFF
--- a/app/src/main/java/com/easyestate/android/ui/LandingScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/LandingScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults


### PR DESCRIPTION
## Summary
- add the missing weight layout import to LandingScreen so the modifier extension resolves

## Testing
- `./gradlew assembleDebug` *(fails: gradle wrapper jar lacks a main manifest attribute in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd62b5d5d48323a271b4d2cdf28a7a