### PR TITLE
Remove deprecated TextField padding argument in login screen

### DIFF
--- a/app/src/main/java/com/easyestate/android/ui/LoginScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/LoginScreen.kt
@@ -3,7 +3,6 @@ package com.easyestate.android.ui
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -121,8 +120,7 @@ fun LoginScreen(
                         unfocusedIndicatorColor = Color.Transparent,
                         disabledIndicatorColor = Color.Transparent,
                         cursorColor = MaterialTheme.colorScheme.primary
-                    ),
-                    contentPadding = PaddingValues(horizontal = 20.dp, vertical = 18.dp)
+                    )
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
@@ -150,8 +148,7 @@ fun LoginScreen(
                         unfocusedIndicatorColor = Color.Transparent,
                         disabledIndicatorColor = Color.Transparent,
                         cursorColor = MaterialTheme.colorScheme.primary
-                    ),
-                    contentPadding = PaddingValues(horizontal = 20.dp, vertical = 18.dp)
+                    )
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
## Summary
- remove usage of the removed contentPadding parameter from the login screen TextField components after the Compose Material3 update

## Testing
- gradle :app:compileDebugKotlin *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd673cbacc83239b34da41b4d962b9