### PR TITLE
Add Compose foundation layout dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.ui:ui-text-google-fonts")
     implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.foundation:foundation-layout")
     implementation("androidx.compose.material3:material3")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.navigation:navigation-compose:2.7.7")


### PR DESCRIPTION
## Summary
- add the Compose foundation layout artifact so weight modifiers resolve in UI screens

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: gradle wrapper jar lacks main manifest attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7040c2508323913f8bf2572c97b2