### PR TITLE
Fix Compose weight imports in landing and login screens

### DIFF
--- a/app/src/main/java/com/easyestate/android/ui/LandingScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/LandingScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.layout.ColumnScope.weight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults

--- a/app/src/main/java/com/easyestate/android/ui/LoginScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/LoginScreen.kt
@@ -10,7 +10,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.layout.ColumnScope.weight
+import androidx.compose.foundation.layout.RowScope.weight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowBack


### PR DESCRIPTION
## Summary
- update the landing screen to import the ColumnScope weight extension
- update the login screen to import both ColumnScope and RowScope weight extensions so Modifier.weight resolves

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: no main manifest attribute in gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68dd759bf088832399e9650e18c5b298