### PR TITLE
Fix compose weight import usage

### DIFF
--- a/app/src/main/java/com/easyestate/android/ui/LandingScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/LandingScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.ColumnScope.weight
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults

--- a/app/src/main/java/com/easyestate/android/ui/LoginScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/LoginScreen.kt
@@ -10,8 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.ColumnScope.weight
-import androidx.compose.foundation.layout.RowScope.weight
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowBack


### PR DESCRIPTION
## Summary
- replace ColumnScope and RowScope weight imports with Modifier weight import
- ensure both landing and login screens rely on the same weight extension import

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: no main manifest attribute in gradle wrapper jar)*

------
https://chatgpt.com/codex/tasks/task_e_68dd79044a7c8323aa4f96332b97f79b