### PR TITLE
Annotate HomeScreen with ExperimentalMaterial3Api opt-in

### DIFF
--- a/app/src/main/java/com/easyestate/android/ui/HomeScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/HomeScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -41,6 +42,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.easyestate.android.ui.theme.EasyEstateTheme
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
     adminName: String,


### PR DESCRIPTION
## Summary
- opt into ExperimentalMaterial3Api in HomeScreen so TopAppBar usage is explicitly acknowledged

## Testing
- ./gradlew :app:assembleDebug *(fails: Gradle wrapper JAR missing main manifest attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7f4cf4388323b1e362f8afec3b98