### PR TITLE
Add home route and navigation handling for authenticated admins

### DIFF
--- a/app/src/main/java/com/easyestate/android/MainActivity.kt
+++ b/app/src/main/java/com/easyestate/android/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.easyestate.android.ui.AuthUiEvent
 import com.easyestate.android.ui.AuthViewModel
+import com.easyestate.android.ui.HomeScreen
 import com.easyestate.android.ui.LandingScreen
 import com.easyestate.android.ui.LoginScreen
 import com.easyestate.android.ui.SignUpScreen
@@ -56,9 +57,9 @@ fun EasyEstateApp(
                     }
                 }
                 is AuthUiEvent.NavigateHome -> {
-                    navController.navigate(AppDestination.Landing.route) {
+                    navController.navigate(AppDestination.Home.route) {
                         popUpTo(navController.graph.findStartDestination().id) {
-                            inclusive = false
+                            inclusive = true
                         }
                         launchSingleTop = true
                     }
@@ -125,6 +126,11 @@ fun EasyEstateApp(
                     isLoading = uiState.isLoading
                 )
             }
+            composable(AppDestination.Home.route) {
+                HomeScreen(
+                    adminName = uiState.currentAdminName.orEmpty()
+                )
+            }
         }
     }
 }
@@ -132,7 +138,8 @@ fun EasyEstateApp(
 private enum class AppDestination(val route: String) {
     Landing("landing"),
     Login("login"),
-    SignUp("sign_up")
+    SignUp("sign_up"),
+    Home("home")
 }
 
 @Preview(showBackground = true)


### PR DESCRIPTION
## Summary
- add a home destination to the app navigation graph and hook it up to HomeScreen
- update NavigateHome events to land on the new home route while clearing prior auth screens

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd88c359188323a40404bc02e4bddf