### PR TITLE
Remove redundant weight imports from UI screens

### DIFF
--- a/app/src/main/java/com/easyestate/android/ui/LandingScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/LandingScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults

--- a/app/src/main/java/com/easyestate/android/ui/LoginScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/LoginScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowBack


### PR DESCRIPTION
## Summary
- remove the explicit foundation weight imports from the landing and login screens

## Testing
- `./gradlew assemble` *(fails: no main manifest attribute in gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8b90e8108323b67a33d0241cdad5