### PR TITLE
Add forgot password flow

### DIFF
--- a/app/src/main/java/com/easyestate/android/MainActivity.kt
+++ b/app/src/main/java/com/easyestate/android/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -21,11 +22,13 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.easyestate.android.ui.AuthUiEvent
 import com.easyestate.android.ui.AuthViewModel
+import com.easyestate.android.ui.ForgotPasswordScreen
 import com.easyestate.android.ui.HomeScreen
 import com.easyestate.android.ui.LandingScreen
 import com.easyestate.android.ui.LoginScreen
 import com.easyestate.android.ui.SignUpScreen
 import com.easyestate.android.ui.theme.EasyEstateTheme
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -46,6 +49,7 @@ fun EasyEstateApp(
     val uiState = authViewModel.uiState.collectAsStateWithLifecycle().value
     val navController = rememberNavController()
     val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
 
     uiState.event?.let { event ->
         LaunchedEffect(event) {
@@ -101,6 +105,11 @@ fun EasyEstateApp(
                             launchSingleTop = true
                         }
                     },
+                    onForgotPassword = {
+                        navController.navigate(AppDestination.ForgotPassword.route) {
+                            launchSingleTop = true
+                        }
+                    },
                     isLoading = uiState.isLoading,
                     onBack = {
                         if (!navController.popBackStack()) {
@@ -126,6 +135,16 @@ fun EasyEstateApp(
                     isLoading = uiState.isLoading
                 )
             }
+            composable(AppDestination.ForgotPassword.route) {
+                ForgotPasswordScreen(
+                    onBack = { navController.popBackStack() },
+                    onSendReset = { email ->
+                        coroutineScope.launch {
+                            snackbarHostState.showSnackbar("Password reset link sent to $email (stub)")
+                        }
+                    }
+                )
+            }
             composable(AppDestination.Home.route) {
                 HomeScreen(
                     adminName = uiState.currentAdminName.orEmpty()
@@ -139,6 +158,7 @@ private enum class AppDestination(val route: String) {
     Landing("landing"),
     Login("login"),
     SignUp("sign_up"),
+    ForgotPassword("forgot_password"),
     Home("home")
 }
 

--- a/app/src/main/java/com/easyestate/android/ui/ForgotPasswordScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/ForgotPasswordScreen.kt
@@ -1,0 +1,166 @@
+package com.easyestate.android.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Email
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.easyestate.android.ui.theme.EasyEstateTheme
+
+@Composable
+fun ForgotPasswordScreen(
+    onBack: () -> Unit,
+    onSendReset: (email: String) -> Unit,
+    modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
+    errorMessage: String? = null,
+) {
+    var email by rememberSaveable { mutableStateOf("") }
+
+    Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp, vertical = 24.dp)
+        ) {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                IconButton(
+                    onClick = onBack,
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.ArrowBack,
+                        contentDescription = "Back",
+                        tint = MaterialTheme.colorScheme.onBackground
+                    )
+                }
+                Text(
+                    text = "Forgot Password",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Text(
+                text = "Reset your password",
+                style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.ExtraBold),
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            Text(
+                text = "Enter the email associated with your account and we'll send you a reset link.",
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                modifier = Modifier.padding(top = 4.dp, bottom = 32.dp)
+            )
+
+            TextField(
+                value = email,
+                onValueChange = { email = it },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = { Text("Email") },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.Email,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                },
+                shape = RoundedCornerShape(16.dp),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    disabledIndicatorColor = Color.Transparent,
+                    cursorColor = MaterialTheme.colorScheme.primary
+                ),
+                enabled = !isLoading
+            )
+
+            if (!errorMessage.isNullOrEmpty()) {
+                Text(
+                    text = errorMessage,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(top = 12.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Button(
+                onClick = { onSendReset(email) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = RoundedCornerShape(14.dp),
+                enabled = !isLoading
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        color = Color.White,
+                        strokeWidth = 2.dp,
+                        modifier = Modifier.size(20.dp)
+                    )
+                } else {
+                    Text(
+                        text = "Send Reset Link",
+                        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ForgotPasswordScreenPreview() {
+    EasyEstateTheme {
+        ForgotPasswordScreen(onBack = {}, onSendReset = {})
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ForgotPasswordScreenLoadingPreview() {
+    EasyEstateTheme {
+        ForgotPasswordScreen(onBack = {}, onSendReset = {}, isLoading = true)
+    }
+}

--- a/app/src/main/java/com/easyestate/android/ui/LoginScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/LoginScreen.kt
@@ -44,6 +44,7 @@ import com.easyestate.android.ui.theme.EasyEstateTheme
 fun LoginScreen(
     onSignIn: (email: String, password: String) -> Unit,
     onSignUp: () -> Unit,
+    onForgotPassword: () -> Unit,
     modifier: Modifier = Modifier,
     isLoading: Boolean = false,
     onBack: () -> Unit = {}
@@ -153,7 +154,7 @@ fun LoginScreen(
                 Spacer(modifier = Modifier.height(16.dp))
 
                 Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
-                    TextButton(onClick = { }) {
+                    TextButton(onClick = onForgotPassword) {
                         Text(
                             text = "Forgot Password?",
                             style = MaterialTheme.typography.bodyMedium,
@@ -215,7 +216,7 @@ fun LoginScreen(
 @Composable
 private fun LoginScreenPreview() {
     EasyEstateTheme {
-        LoginScreen(onSignIn = { _, _ -> }, onSignUp = {})
+        LoginScreen(onSignIn = { _, _ -> }, onSignUp = {}, onForgotPassword = {})
     }
 }
 
@@ -223,6 +224,6 @@ private fun LoginScreenPreview() {
 @Composable
 private fun LoginScreenLoadingPreview() {
     EasyEstateTheme {
-        LoginScreen(onSignIn = { _, _ -> }, onSignUp = {}, isLoading = true)
+        LoginScreen(onSignIn = { _, _ -> }, onSignUp = {}, onForgotPassword = {}, isLoading = true)
     }
 }


### PR DESCRIPTION
## Summary
- add a forgot password destination and navigate to it from the login screen
- implement the forgot password UI with callbacks for sending the reset link and returning to login

## Testing
- ./gradlew lint *(fails: no main manifest attribute in gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68de1be1e47c832394b5593ff3cdc929