### PR TITLE
Refactor Home screen dashboard

### DIFF
--- a/app/src/main/java/com/easyestate/android/ui/HomeScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/HomeScreen.kt
@@ -1,7 +1,5 @@
 package com.easyestate.android.ui
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,247 +9,299 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.material.icons.outlined.Apartment
+import androidx.compose.material.icons.outlined.BarChart
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.ReceiptLong
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.easyestate.android.ui.theme.EasyEstateTheme
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
     adminName: String,
+    hasUnreadNotifications: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
-    var searchQuery by remember { mutableStateOf("") }
-    var showOnlyFavorites by remember { mutableStateOf(false) }
-    var highlightedPropertyId by remember { mutableStateOf<Int?>(null) }
-
-    val properties = remember { sampleProperties() }
-    val filteredProperties = remember(searchQuery, showOnlyFavorites, highlightedPropertyId) {
-        properties.filter { property ->
-            val matchesQuery = property.title.contains(searchQuery, ignoreCase = true) ||
-                property.location.contains(searchQuery, ignoreCase = true)
-            val matchesFavorites = !showOnlyFavorites || property.isFavorite
-            matchesQuery && matchesFavorites
-        }.map { property ->
-            if (property.id == highlightedPropertyId) {
-                property.copy(isHighlighted = true)
-            } else {
-                property.copy(isHighlighted = false)
-            }
-        }
-    }
+    val quickActions = DashboardQuickActions
 
     Surface(modifier = modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
-            TopAppBar(
-                title = {
-                    Column {
-                        Text(
-                            text = "Welcome back",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                        )
-                        Text(
-                            text = adminName,
-                            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                            color = MaterialTheme.colorScheme.onPrimaryContainer
-                        )
-                    }
-                },
-                actions = {
-                    val favoriteIcon = if (showOnlyFavorites) {
-                        Icons.Filled.Favorite
-                    } else {
-                        Icons.Outlined.FavoriteBorder
-                    }
-                    val iconTint = if (showOnlyFavorites) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.onPrimaryContainer
-                    }
-                    Box(
-                        modifier = Modifier
-                            .padding(horizontal = 16.dp)
-                            .clip(CircleShape)
-                            .clickable { showOnlyFavorites = !showOnlyFavorites }
-                            .background(
-                                color = if (showOnlyFavorites) {
-                                    MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
-                                } else {
-                                    Color.Transparent
-                                }
-                            )
-                            .padding(12.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            imageVector = favoriteIcon,
-                            contentDescription = null,
-                            tint = iconTint
-                        )
-                    }
-                }
-            )
-
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 24.dp, vertical = 16.dp)
+                    .padding(horizontal = 24.dp)
+                    .padding(top = 32.dp)
             ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text(
+                            text = "Welcome back",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                        )
+                        Text(
+                            text = adminName,
+                            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                            color = MaterialTheme.colorScheme.onBackground
+                        )
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        IconButton(onClick = { }) {
+                            Icon(
+                                imageVector = Icons.Outlined.Search,
+                                contentDescription = "Search",
+                                tint = MaterialTheme.colorScheme.onBackground
+                            )
+                        }
+                        BadgedBox(
+                            badge = {
+                                if (hasUnreadNotifications) {
+                                    Badge()
+                                }
+                            }
+                        ) {
+                            IconButton(onClick = { }) {
+                                Icon(
+                                    imageVector = Icons.Outlined.Notifications,
+                                    contentDescription = "Notifications",
+                                    tint = MaterialTheme.colorScheme.onBackground
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.large,
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(24.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text(
+                            text = "Occupancy Overview",
+                            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.Bottom
+                        ) {
+                            OccupancyStat(label = "Occupied", value = "48")
+                            OccupancyStat(label = "Vacant", value = "12")
+                            OccupancyStat(label = "Upcoming", value = "5")
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(32.dp))
+
                 Text(
-                    text = "Discover premium properties",
-                    style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                    text = "Quick Actions",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
                     color = MaterialTheme.colorScheme.onBackground
                 )
+
                 Spacer(modifier = Modifier.height(16.dp))
-                OutlinedTextField(
-                    value = searchQuery,
-                    onValueChange = { searchQuery = it },
-                    label = { Text("Search by city or property") },
-                    modifier = Modifier.fillMaxWidth()
-                )
+
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(4),
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(quickActions) { action ->
+                        QuickActionTile(action = action)
+                    }
+                }
             }
 
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(24.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            NavigationBar(
+                containerColor = MaterialTheme.colorScheme.surface,
+                tonalElevation = 0.dp
             ) {
-                items(filteredProperties) { property ->
-                    PropertyCard(
-                        property = property,
-                        onClick = { highlightedPropertyId = property.id }
+                NavigationBarItem(
+                    selected = true,
+                    onClick = { },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.Home,
+                            contentDescription = "Home"
+                        )
+                    },
+                    label = { Text("Home") },
+                    colors = NavigationBarItemDefaults.colors(
+                        selectedIconColor = MaterialTheme.colorScheme.primary,
+                        selectedTextColor = MaterialTheme.colorScheme.primary,
+                        indicatorColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
                     )
-                }
+                )
+                NavigationBarItem(
+                    selected = false,
+                    onClick = { },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.Apartment,
+                            contentDescription = "Portfolio"
+                        )
+                    },
+                    label = { Text("Portfolio") }
+                )
+                NavigationBarItem(
+                    selected = false,
+                    onClick = { },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.AccountCircle,
+                            contentDescription = "Tenants"
+                        )
+                    },
+                    label = { Text("Tenants") }
+                )
+                NavigationBarItem(
+                    selected = false,
+                    onClick = { },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.Settings,
+                            contentDescription = "Settings"
+                        )
+                    },
+                    label = { Text("Settings") }
+                )
             }
         }
     }
 }
 
 @Composable
-private fun PropertyCard(
-    property: Property,
-    onClick: () -> Unit,
+private fun OccupancyStat(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold)
+        )
+    }
+}
+
+@Composable
+private fun QuickActionTile(
+    action: QuickAction,
     modifier: Modifier = Modifier
 ) {
     Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
+        modifier = modifier.aspectRatio(1f),
+        shape = MaterialTheme.shapes.medium,
         colors = CardDefaults.cardColors(
-            containerColor = if (property.isHighlighted) {
-                MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
-            } else {
-                MaterialTheme.colorScheme.surface
-            }
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
         )
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = property.title,
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    Text(
-                        text = property.location,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                Spacer(modifier = Modifier.size(16.dp))
+                Icon(
+                    imageVector = action.icon,
+                    contentDescription = action.title
+                )
                 Text(
-                    text = property.price,
-                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                    color = MaterialTheme.colorScheme.primary
+                    text = action.title,
+                    style = MaterialTheme.typography.labelMedium
                 )
             }
-
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(
-                text = property.description,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
         }
     }
 }
 
-data class Property(
-    val id: Int,
+private data class QuickAction(
     val title: String,
-    val location: String,
-    val price: String,
-    val description: String,
-    val isFavorite: Boolean,
-    val isHighlighted: Boolean = false
+    val icon: ImageVector,
 )
 
-private fun sampleProperties(): List<Property> = listOf(
-    Property(
-        id = 1,
-        title = "Modern Family Home",
-        location = "Lagos, Nigeria",
-        price = "₦85,000,000",
-        description = "A spacious 4-bedroom home with a private garden and smart security system.",
-        isFavorite = true
-    ),
-    Property(
-        id = 2,
-        title = "Luxury Waterfront Apartment",
-        location = "Abuja, Nigeria",
-        price = "₦120,000,000",
-        description = "Premium waterfront living with panoramic views, concierge, and pool access.",
-        isFavorite = false
-    ),
-    Property(
-        id = 3,
-        title = "Urban Smart Condo",
-        location = "Port Harcourt, Nigeria",
-        price = "₦68,000,000",
-        description = "Smart-enabled condo featuring co-working space, gym, and rooftop lounge.",
-        isFavorite = true
-    )
+private val DashboardQuickActions = listOf(
+    QuickAction("New Lease", Icons.Outlined.ReceiptLong),
+    QuickAction("Add Unit", Icons.Outlined.Apartment),
+    QuickAction("Analytics", Icons.Outlined.BarChart),
+    QuickAction("Profile", Icons.Outlined.AccountCircle),
+    QuickAction("Payments", Icons.Outlined.ReceiptLong),
+    QuickAction("Maintenance", Icons.Outlined.Settings),
+    QuickAction("Reports", Icons.Outlined.BarChart),
+    QuickAction("Support", Icons.Outlined.Settings)
 )
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun HomeScreenPreview() {
     EasyEstateTheme {
         HomeScreen(adminName = "Easy Estate Admin")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HomeScreenPreviewWithNotifications() {
+    EasyEstateTheme {
+        HomeScreen(adminName = "Easy Estate Admin", hasUnreadNotifications = true)
     }
 }


### PR DESCRIPTION
## Summary
- rebuild the Home screen with the new dashboard layout including greeting, occupancy overview, and quick action grid
- add a bottom navigation bar with Home selected and placeholders for upcoming sections
- refresh Compose previews to cover the default and notification badge states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de2062180483238c78f4144b8c8a0a