### PR TITLE
Refine HomeScreen to support injected dashboard data

### DIFF
--- a/app/src/main/java/com/easyestate/android/MainActivity.kt
+++ b/app/src/main/java/com/easyestate/android/MainActivity.kt
@@ -4,6 +4,10 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.List
+import androidx.compose.material.icons.outlined.MailOutline
+import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -24,6 +28,7 @@ import com.easyestate.android.ui.AuthUiEvent
 import com.easyestate.android.ui.AuthViewModel
 import com.easyestate.android.ui.ForgotPasswordScreen
 import com.easyestate.android.ui.HomeScreen
+import com.easyestate.android.ui.QuickAction
 import com.easyestate.android.ui.LandingScreen
 import com.easyestate.android.ui.LoginScreen
 import com.easyestate.android.ui.SignUpScreen
@@ -146,8 +151,22 @@ fun EasyEstateApp(
                 )
             }
             composable(AppDestination.Home.route) {
+                val quickActions = remember {
+                    listOf(
+                        QuickAction(label = "Add property", icon = Icons.Outlined.List, onClick = {}),
+                        QuickAction(label = "Invite tenant", icon = Icons.Outlined.Person, onClick = {}),
+                        QuickAction(label = "Send notice", icon = Icons.Outlined.MailOutline, onClick = {}),
+                    )
+                }
                 HomeScreen(
-                    adminName = uiState.currentAdminName.orEmpty()
+                    adminName = uiState.currentAdminName.orEmpty(),
+                    occupiedUnits = 24,
+                    vacantUnits = 6,
+                    quickActions = quickActions,
+                    onSelectHome = {},
+                    onSelectProperties = {},
+                    onSelectMessages = {},
+                    onSelectProfile = {}
                 )
             }
         }

--- a/app/src/main/java/com/easyestate/android/ui/HomeScreen.kt
+++ b/app/src/main/java/com/easyestate/android/ui/HomeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,18 +13,28 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.List
+import androidx.compose.material.icons.outlined.MailOutline
+import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -36,6 +47,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -46,11 +58,19 @@ import com.easyestate.android.ui.theme.EasyEstateTheme
 @Composable
 fun HomeScreen(
     adminName: String,
+    occupiedUnits: Int,
+    vacantUnits: Int,
+    quickActions: List<QuickAction>,
+    onSelectHome: () -> Unit,
+    onSelectProperties: () -> Unit,
+    onSelectMessages: () -> Unit,
+    onSelectProfile: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var searchQuery by remember { mutableStateOf("") }
     var showOnlyFavorites by remember { mutableStateOf(false) }
     var highlightedPropertyId by remember { mutableStateOf<Int?>(null) }
+    var selectedDestination by remember { mutableStateOf(HomeBottomDestination.Home) }
 
     val properties = remember { sampleProperties() }
     val filteredProperties = remember(searchQuery, showOnlyFavorites, highlightedPropertyId) {
@@ -69,88 +89,265 @@ fun HomeScreen(
     }
 
     Surface(modifier = modifier.fillMaxSize()) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            TopAppBar(
-                title = {
-                    Column {
-                        Text(
-                            text = "Welcome back",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                        )
-                        Text(
-                            text = adminName,
-                            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                            color = MaterialTheme.colorScheme.onPrimaryContainer
-                        )
+        Scaffold(
+            bottomBar = {
+                HomeBottomNavigation(
+                    selectedDestination = selectedDestination,
+                    onDestinationSelected = { destination ->
+                        selectedDestination = destination
+                        when (destination) {
+                            HomeBottomDestination.Home -> onSelectHome()
+                            HomeBottomDestination.Properties -> onSelectProperties()
+                            HomeBottomDestination.Messages -> onSelectMessages()
+                            HomeBottomDestination.Profile -> onSelectProfile()
+                        }
                     }
-                },
-                actions = {
-                    val favoriteIcon = if (showOnlyFavorites) {
-                        Icons.Filled.Favorite
-                    } else {
-                        Icons.Outlined.FavoriteBorder
-                    }
-                    val iconTint = if (showOnlyFavorites) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.onPrimaryContainer
-                    }
-                    Box(
-                        modifier = Modifier
-                            .padding(horizontal = 16.dp)
-                            .clip(CircleShape)
-                            .clickable { showOnlyFavorites = !showOnlyFavorites }
-                            .background(
-                                color = if (showOnlyFavorites) {
-                                    MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
-                                } else {
-                                    Color.Transparent
-                                }
-                            )
-                            .padding(12.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            imageVector = favoriteIcon,
-                            contentDescription = null,
-                            tint = iconTint
-                        )
-                    }
-                }
-            )
-
+                )
+            }
+        ) { innerPadding ->
             Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp, vertical = 16.dp)
+                    .fillMaxSize()
+                    .padding(innerPadding)
             ) {
-                Text(
-                    text = "Discover premium properties",
-                    style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
-                    color = MaterialTheme.colorScheme.onBackground
+                TopAppBar(
+                    title = {
+                        Column {
+                            Text(
+                                text = "Welcome back",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                            )
+                            Text(
+                                text = adminName,
+                                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                                color = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                        }
+                    },
+                    actions = {
+                        val favoriteIcon = if (showOnlyFavorites) {
+                            Icons.Filled.Favorite
+                        } else {
+                            Icons.Outlined.FavoriteBorder
+                        }
+                        val iconTint = if (showOnlyFavorites) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        }
+                        Box(
+                            modifier = Modifier
+                                .padding(horizontal = 16.dp)
+                                .clip(CircleShape)
+                                .clickable { showOnlyFavorites = !showOnlyFavorites }
+                                .background(
+                                    color = if (showOnlyFavorites) {
+                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+                                    } else {
+                                        Color.Transparent
+                                    }
+                                )
+                                .padding(12.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = favoriteIcon,
+                                contentDescription = null,
+                                tint = iconTint
+                            )
+                        }
+                    }
                 )
-                Spacer(modifier = Modifier.height(16.dp))
-                OutlinedTextField(
-                    value = searchQuery,
-                    onValueChange = { searchQuery = it },
-                    label = { Text("Search by city or property") },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
 
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(24.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                items(filteredProperties) { property ->
-                    PropertyCard(
-                        property = property,
-                        onClick = { highlightedPropertyId = property.id }
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 16.dp)
+                ) {
+                    Text(
+                        text = "Discover premium properties",
+                        style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                        color = MaterialTheme.colorScheme.onBackground
                     )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    OutlinedTextField(
+                        value = searchQuery,
+                        onValueChange = { searchQuery = it },
+                        label = { Text("Search by city or property") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(modifier = Modifier.height(24.dp))
+                    UnitOverviewRow(
+                        occupiedUnits = occupiedUnits,
+                        vacantUnits = vacantUnits
+                    )
+                    if (quickActions.isNotEmpty()) {
+                        Spacer(modifier = Modifier.height(24.dp))
+                        QuickActionsRow(quickActions = quickActions)
+                    }
+                }
+
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(filteredProperties) { property ->
+                        PropertyCard(
+                            property = property,
+                            onClick = { highlightedPropertyId = property.id }
+                        )
+                    }
                 }
             }
+        }
+    }
+}
+
+private enum class HomeBottomDestination(val label: String, val icon: ImageVector) {
+    Home(label = "Home", icon = Icons.Filled.Home),
+    Properties(label = "Properties", icon = Icons.Outlined.List),
+    Messages(label = "Messages", icon = Icons.Outlined.MailOutline),
+    Profile(label = "Profile", icon = Icons.Outlined.Person)
+}
+
+data class QuickAction(
+    val label: String,
+    val icon: ImageVector,
+    val onClick: () -> Unit,
+)
+
+@Composable
+private fun HomeBottomNavigation(
+    selectedDestination: HomeBottomDestination,
+    onDestinationSelected: (HomeBottomDestination) -> Unit,
+) {
+    NavigationBar {
+        HomeBottomDestination.values().forEach { destination ->
+            NavigationBarItem(
+                selected = destination == selectedDestination,
+                onClick = { onDestinationSelected(destination) },
+                icon = {
+                    Icon(
+                        imageVector = destination.icon,
+                        contentDescription = destination.label
+                    )
+                },
+                label = { Text(text = destination.label) },
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = MaterialTheme.colorScheme.onPrimary,
+                    selectedTextColor = MaterialTheme.colorScheme.onPrimary,
+                    selectedIndicatorColor = MaterialTheme.colorScheme.primary,
+                    unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun UnitOverviewRow(
+    occupiedUnits: Int,
+    vacantUnits: Int,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        UnitOverviewCard(
+            title = "Occupied units",
+            count = occupiedUnits,
+            backgroundColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+            contentColor = MaterialTheme.colorScheme.primary
+        )
+        UnitOverviewCard(
+            title = "Vacant units",
+            count = vacantUnits,
+            backgroundColor = MaterialTheme.colorScheme.secondary.copy(alpha = 0.12f),
+            contentColor = MaterialTheme.colorScheme.secondary
+        )
+    }
+}
+
+@Composable
+private fun UnitOverviewCard(
+    title: String,
+    count: Int,
+    backgroundColor: Color,
+    contentColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.weight(1f),
+        colors = CardDefaults.cardColors(
+            containerColor = backgroundColor,
+            contentColor = contentColor
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyMedium,
+                color = contentColor.copy(alpha = 0.8f)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = count.toString(),
+                style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                color = contentColor
+            )
+        }
+    }
+}
+
+@Composable
+private fun QuickActionsRow(
+    quickActions: List<QuickAction>,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        items(quickActions) { action ->
+            QuickActionCard(action = action)
+        }
+    }
+}
+
+@Composable
+private fun QuickActionCard(
+    action: QuickAction,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier
+            .widthIn(min = 160.dp)
+            .clickable(onClick = action.onClick),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(
+                imageVector = action.icon,
+                contentDescription = action.label,
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Text(
+                text = action.label,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
         }
     }
 }
@@ -252,6 +449,19 @@ private fun sampleProperties(): List<Property> = listOf(
 @Composable
 private fun HomeScreenPreview() {
     EasyEstateTheme {
-        HomeScreen(adminName = "Easy Estate Admin")
+        HomeScreen(
+            adminName = "Easy Estate Admin",
+            occupiedUnits = 26,
+            vacantUnits = 8,
+            quickActions = listOf(
+                QuickAction(label = "Add property", icon = Icons.Outlined.List, onClick = {}),
+                QuickAction(label = "Invite tenant", icon = Icons.Outlined.Person, onClick = {}),
+                QuickAction(label = "Send notice", icon = Icons.Outlined.MailOutline, onClick = {}),
+            ),
+            onSelectHome = {},
+            onSelectProperties = {},
+            onSelectMessages = {},
+            onSelectProfile = {}
+        )
     }
 }


### PR DESCRIPTION
## Summary
- expand `HomeScreen` to accept occupancy totals, quick action models, and navigation callbacks
- render the dashboard overview, quick actions, and bottom navigation using the supplied data and refresh the preview
- provide temporary stub dashboard data from `MainActivity` until real sources are connected

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: no main manifest attribute in gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68de20798a948323887c2fb97121bd8b