### PR TITLE
Add material icons extended dependency for Compose

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-text-google-fonts")
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.foundation:foundation-layout")
+    implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.compose.material3:material3")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.navigation:navigation-compose:2.7.7")


### PR DESCRIPTION
## Summary
- add the androidx.compose.material:material-icons-extended dependency so Icons.Outlined usages resolve

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de28346b188323aaa7db4a04237a7d